### PR TITLE
Add perms command tests and docs

### DIFF
--- a/codex/perms_command_shortcomings.md
+++ b/codex/perms_command_shortcomings.md
@@ -1,0 +1,21 @@
+# Potential Shortcomings of the `perms` Command
+
+The implementation in `keepercommander/commands/perms_command.py` is designed for automation but has a few limitations:
+
+1. **Minimal Validation**
+   - `validate_csv` only checks for file existence. It does not verify column names or permission values. Invalid input may lead to runtime errors during `apply`.
+2. **Error Handling**
+   - Many operations rely on network API calls. Failures (e.g., connectivity issues or missing vault records) are logged but not raised, which can make debugging difficult.
+3. **Fixed Config Record**
+   - The command stores artifacts in a record titled "Perms Config". If the record is deleted or renamed, commands may fail until recreated.
+4. **Team Lookup**
+   - Team names are matched exactly. Typos in the CSV cause "Team not found" errors that stop permission updates for that row.
+5. **Scalability**
+   - `apply_permissions` processes each CSV row sequentially and performs multiple API calls per record/team. Large CSV files may result in long execution times.
+6. **Limited Unit Tests**
+   - Prior to this update, there were no automated tests covering `perms`. The new tests focus on high-level invocation but do not exercise the full API integration.
+7. **Interactive Mode**
+   - Interactive prompts pause execution for user input, which may not be desirable in automated environments.
+
+Consider these factors when relying on `perms` for large-scale or unattended automation.
+

--- a/codex/perms_command_tests.md
+++ b/codex/perms_command_tests.md
@@ -1,0 +1,14 @@
+# `perms` Command Test Summary
+
+Automated tests were added in `unit-tests/test_perms_command.py` to ensure the CLI integrates correctly with the `perms` subcommands. The tests mock API interactions and verify that high-level methods are invoked:
+
+- **Template generation**
+  - `perms template --vault-only` calls `generate_template` and `store_in_vault_bytes`.
+  - `perms template <file>` writes to a local file and stores it in the vault.
+- **Validation**
+  - `perms validate --vault-csv TITLE` downloads the attachment, validates it, and prints `Valid`.
+- **Apply**
+  - `perms apply <file> --dry-run` invokes `apply_permissions` with the correct arguments.
+
+All tests run with `pytest unit-tests/test_perms_command.py` and pass after patching network calls.
+

--- a/codex/perms_command_usage.md
+++ b/codex/perms_command_usage.md
@@ -1,0 +1,49 @@
+# `perms` Command Usage
+
+The `perms` command automates record permissions inside Keeper. It provides three subcommands:
+
+- `perms template [OUTPUT] [--vault-only]`
+- `perms validate [CSV_PATH] [--vault-csv TITLE]`
+- `perms apply [CSV_PATH] [--dry-run] [--interactive] [--root NAME] [--vault-csv TITLE]`
+
+## `template`
+Generates a CSV template listing available records and teams. The CSV contains `Record UID`, `Title`, `Folder Path`, followed by a column for each team. Use it to specify permission levels per team.
+
+Options:
+- `OUTPUT`: Path to save the CSV locally.
+- `--vault-only`: Write the template directly to a vault record attachment rather than a local file.
+
+## `validate`
+Validates a permissions CSV file before applying changes.
+
+Options:
+- `CSV_PATH`: Path to the CSV file.
+- `--vault-csv TITLE`: Download the specified attachment from the "Perms Config" record in the vault and validate it.
+
+## `apply`
+Applies permissions from a CSV file. Each row specifies a record and permission levels for teams. Folders are automatically created under a root folder (default `[Perms]`).
+
+Options:
+- `CSV_PATH`: Path to the CSV file with permissions.
+- `--dry-run`: Parse the CSV and display actions without making changes.
+- `--interactive`: Prompt for folder and record names when creating configuration entries.
+- `--root NAME`: Custom root folder for created folder structure.
+- `--vault-csv TITLE`: Use a CSV attachment from the "Perms Config" record.
+
+### Permission Levels
+The following values map to specific permission flags:
+
+| Level | Can Edit | Can Share | Manage Records | Manage Users |
+|-------|---------|-----------|----------------|--------------|
+| `ro`  | ✗       | ✗         | ✗              | ✗            |
+| `rw`  | ✓       | ✗         | ✗              | ✗            |
+| `rws` | ✓       | ✓         | ✗              | ✗            |
+| `mgr` | ✓       | ✓         | ✓              | ✗            |
+| `admin` | ✓     | ✓         | ✓              | ✓            |
+
+### Example Workflow
+1. Generate a template: `perms template perms.csv`
+2. Fill in permission levels per team.
+3. Validate the file: `perms validate perms.csv`
+4. Apply permissions: `perms apply perms.csv`
+

--- a/keepercommander/commands/perms_command.py
+++ b/keepercommander/commands/perms_command.py
@@ -16,7 +16,8 @@ from keepercommander.record_management import add_record_to_folder
 from keepercommander.vault import KeeperRecord
 from keepercommander import utils
 from keepercommander.proto import record_pb2
-from keepercommander.attachment import FileUploadTask, prepare_attachment_download, AttachmentDownloadRequest, BytesUploadTask, upload_attachments, update_record
+from keepercommander.attachment import FileUploadTask, prepare_attachment_download, AttachmentDownloadRequest, BytesUploadTask, upload_attachments
+from keepercommander.record_management import update_record
 from io import StringIO
 import io
 import tempfile

--- a/unit-tests/test_perms_command.py
+++ b/unit-tests/test_perms_command.py
@@ -1,0 +1,63 @@
+import csv
+import os
+from unittest import TestCase, mock
+from collections import OrderedDict
+
+from keepercommander.commands import base
+from keepercommander.cli import do_command
+from keepercommander.commands.perms_command import KeeperPerms
+from data_vault import get_connected_params
+
+
+class TestPermsCommand(TestCase):
+    def setUp(self):
+        base.commands.clear()
+        base.aliases.clear()
+        base.command_info.clear()
+        base.register_commands(base.commands, base.aliases, base.command_info)
+
+    def test_template_vault_only(self):
+        params = get_connected_params()
+        with mock.patch.object(KeeperPerms, 'generate_template') as mock_gen, \
+             mock.patch.object(KeeperPerms, 'store_in_vault_bytes') as mock_store, \
+             mock.patch('keepercommander.api.sync_down'):
+            do_command(params, 'perms template --vault-only')
+            self.assertTrue(mock_gen.called)
+            self.assertTrue(mock_store.called)
+
+    def test_template_file(self):
+        params = get_connected_params()
+        with mock.patch.object(KeeperPerms, 'generate_template') as mock_gen, \
+             mock.patch.object(KeeperPerms, 'store_in_vault') as mock_store, \
+             mock.patch('keepercommander.api.sync_down'):
+            with open('tmp.csv', 'w') as tmp:
+                path = tmp.name
+            do_command(params, f'perms template {path}')
+            mock_gen.assert_called_with(path)
+            self.assertTrue(mock_store.called)
+            os.unlink(path)
+
+    def test_validate_vault_csv(self):
+        params = get_connected_params()
+        with mock.patch.object(KeeperPerms, 'download_from_vault', return_value='file.csv') as mock_download, \
+             mock.patch.object(KeeperPerms, 'validate_csv', return_value=True) as mock_validate, \
+             mock.patch('builtins.print') as mock_print, \
+             mock.patch('os.unlink') as mock_unlink, \
+             mock.patch('keepercommander.api.sync_down'):
+            do_command(params, 'perms validate --vault-csv sample.csv')
+            mock_download.assert_called_with('sample.csv')
+            mock_validate.assert_called_with('file.csv')
+            mock_print.assert_called_with('Valid')
+
+    def test_apply_permissions_called(self):
+        params = get_connected_params()
+        with open('apply.csv', 'w', newline='') as tmp:
+            writer = csv.writer(tmp)
+            writer.writerow(['Record UID', 'Title', 'Folder Path', 'Team1'])
+            writer.writerow(['UID', 'Record', '/folder', 'ro'])
+            path = tmp.name
+        with mock.patch.object(KeeperPerms, 'apply_permissions') as mock_apply, \
+             mock.patch('keepercommander.api.sync_down'):
+            do_command(params, f'perms apply {path} --dry-run')
+            mock_apply.assert_called_with(path, dry_run=True, root_name='[Perms]')
+        os.unlink(path)


### PR DESCRIPTION
## Summary
- fix bad import for update_record in `perms_command`
- add unit tests covering perms command invocation
- document perms command usage and shortcomings under `codex`

## Testing
- `pytest unit-tests/test_perms_command.py -q`

------
https://chatgpt.com/codex/tasks/task_b_687d70648a5083229771f8fe53cacf00