### PR TITLE
Add contributor docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Agent Instructions
+
+This file provides guidance for AI agents contributing to this repository.
+
+## Testing
+
+1. Create a Python virtual environment and activate it.
+   ```bash
+   python3 -m venv venv
+   . venv/bin/activate
+   pip install -U pip
+   ```
+2. Install project dependencies and development tools.
+   ```bash
+   pip install -r requirements.txt
+   pip install -r requirements-dev.txt
+   pip install pytest
+   pip install -e .
+   ```
+3. Run the test suite.
+   ```bash
+   pytest -q
+   ```
+   Some tests require configuration files (for example `tests/config.json`) and may fail if those files or external services are unavailable.
+
+## Documentation Notes
+
+Repository documentation references the [official Keeper Commander documentation](https://docs.keeper.io/secrets-manager/commander-cli/overview). Review that site for detailed usage instructions.
+
+Additional documentation and notes are stored in the `codex` directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,14 @@ This file provides guidance for AI agents contributing to this repository.
 
 ## Testing
 
-1. Create a Python virtual environment and activate it.
+1. Activate the provided Python virtual environment (located at `.venv`).
    ```bash
-   python3 -m venv venv
-   . venv/bin/activate
+   . .venv/bin/activate
+   ```
+   If the `.venv` directory does not exist, create it first:
+   ```bash
+   python3 -m venv .venv
+   . .venv/bin/activate
    pip install -U pip
    ```
 2. Install project dependencies and development tools.

--- a/codex/README.md
+++ b/codex/README.md
@@ -4,3 +4,4 @@ This directory contains documentation and notes for developers and AI agents wor
 
 * `testing.md` – steps to set up the environment and run tests.
 * `documentation_review.md` – notes and suggestions for improving external documentation.
+* `.venv/` – preconfigured virtual environment used for running tests.

--- a/codex/README.md
+++ b/codex/README.md
@@ -1,0 +1,6 @@
+# Codex Documentation
+
+This directory contains documentation and notes for developers and AI agents working on this project.
+
+* `testing.md` – steps to set up the environment and run tests.
+* `documentation_review.md` – notes and suggestions for improving external documentation.

--- a/codex/documentation_review.md
+++ b/codex/documentation_review.md
@@ -8,6 +8,11 @@ Commander Overview | Keeper Documentation
 ```
 It describes the Keeper Commander CLI for IT admins, DevOps and developers and includes an overview of features and setup instructions.
 
+Key topics covered include:
+* Installation steps for various operating systems using Python's package manager.
+* Overview of commands to manage vault records and rotate credentials.
+* Notes on integrating Commander in CI/CD pipelines.
+
 ## Enhancement Suggestions
 
 * Include a short summary of installation steps directly in the repository `README.md` so users can get started quickly without visiting the external site.

--- a/codex/documentation_review.md
+++ b/codex/documentation_review.md
@@ -1,0 +1,15 @@
+# Documentation Review
+
+The main `README.md` links to external documentation at <https://docs.keeper.io/secrets-manager/commander-cli/overview>.
+
+The page title is:
+```
+Commander Overview | Keeper Documentation
+```
+It describes the Keeper Commander CLI for IT admins, DevOps and developers and includes an overview of features and setup instructions.
+
+## Enhancement Suggestions
+
+* Include a short summary of installation steps directly in the repository `README.md` so users can get started quickly without visiting the external site.
+* Add a section on running tests and contributing guidelines.
+* Provide examples of common commands in the `README.md` for quick reference.

--- a/codex/testing.md
+++ b/codex/testing.md
@@ -1,0 +1,23 @@
+# Testing Guide
+
+Follow these steps to run the project tests.
+
+1. Create a virtual environment and activate it:
+   ```bash
+   python3 -m venv venv
+   . venv/bin/activate
+   pip install -U pip
+   ```
+2. Install dependencies and dev requirements:
+   ```bash
+   pip install -r requirements.txt
+   pip install -r requirements-dev.txt
+   pip install pytest
+   pip install -e .
+   ```
+3. Run the tests from the repository root:
+   ```bash
+   pytest -q
+   ```
+
+Tests may require additional configuration files found under `tests/`. Some integration tests rely on external Keeper accounts and will fail without proper credentials.

--- a/codex/testing.md
+++ b/codex/testing.md
@@ -2,10 +2,14 @@
 
 Follow these steps to run the project tests.
 
-1. Create a virtual environment and activate it:
+1. Activate the preconfigured virtual environment in the repository root:
    ```bash
-   python3 -m venv venv
-   . venv/bin/activate
+   . .venv/bin/activate
+   ```
+   If `.venv` does not exist, create it:
+   ```bash
+   python3 -m venv .venv
+   . .venv/bin/activate
    pip install -U pip
    ```
 2. Install dependencies and dev requirements:


### PR DESCRIPTION
## Summary
- add AGENTS.md with testing instructions and documentation notes
- create `codex` docs folder with testing guide and documentation review

## Testing
- `pytest -q` *(fails: ImportError - update_record missing in keepercommander)*

------
https://chatgpt.com/codex/tasks/task_b_687d7058730483229c11eeb5041b40f2