### PR TITLE
Move helper to dedicated module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,19 @@ This file provides guidance for AI agents contributing to this repository.
 Repository documentation references the [official Keeper Commander documentation](https://docs.keeper.io/secrets-manager/commander-cli/overview). Review that site for detailed usage instructions.
 
 Additional documentation and notes are stored in the `codex` directory.
+
+## Helper Function Guidelines
+
+Helper functions are typically added to existing modules near related logic
+(for example `keepercommander/api.py` or the modules under
+`keepercommander/commands/helpers`).
+They use type hint comments and may include a short docstring.
+
+```python
+def example_helper(params, uid):  # type: (KeeperParams, str) -> None
+    """Describe the helper purpose."""
+    ...
+```
+
+Place new helpers below existing ones with a blank line separation.
+No updates to `__init__.py` files are required when adding standalone helpers.

--- a/codex/helper_function_guidelines.md
+++ b/codex/helper_function_guidelines.md
@@ -1,0 +1,9 @@
+# Helper Function Guidelines
+
+This document summarizes how helper functions are typically added in the project.
+
+* Place new helpers near related code, either in `keepercommander/api.py` or within `keepercommander/commands/helpers`.
+* Use a `# type:` comment after the function declaration to indicate parameter and return types.
+* A short docstring is optional but recommended when the function performs non-trivial logic.
+* Separate helper definitions with a blank line for readability.
+* Standalone helper functions usually do not require an entry in `__init__.py`.

--- a/codex/perms_command_feature_recommendations.md
+++ b/codex/perms_command_feature_recommendations.md
@@ -1,0 +1,19 @@
+# `perms` Command Feature Suggestions
+
+Based on manual testing and review, the following enhancements could improve usability:
+
+1. **Permission Summary Report**
+   - After applying permissions, generate a concise report listing records, teams and effective permission levels.
+   - Store this report alongside the log attachment for auditing.
+
+2. **CSV Export of Current Permissions**
+   - Provide a flag to export existing team permissions for records, enabling a full round‑trip workflow.
+
+3. **Granular Error Messages**
+   - Include record titles and folder paths when reporting failures to apply a permission.
+
+4. **Dry‑Run Diff Mode**
+   - When `--dry-run` is specified, show the difference between current and desired permissions to help with change reviews.
+
+5. **Configurable Log Retention**
+   - Allow setting how many log attachments to keep in the vault to avoid clutter.

--- a/codex/perms_command_manual_testing.md
+++ b/codex/perms_command_manual_testing.md
@@ -1,0 +1,37 @@
+# Manual Testing Strategy for `perms` Command
+
+This guide outlines how to manually test the `perms` command without relying on automated tests.
+
+## Prerequisites
+- A Keeper account with vault access and at least one team.
+- Commander configured and logged in (`keeper shell` or via config file).
+- Sample records and folders in the vault to work with.
+
+## Steps
+1. **Generate Template**
+   - Run `perms template perms.csv` to create a CSV locally.
+   - Confirm the file lists existing records and teams.
+   - Run `perms template --vault-only` to store a template attachment in the vault. Verify the attachment exists in the "Perms Config" record.
+
+2. **Populate CSV**
+   - Edit `perms.csv` and set permission levels (`ro`, `rw`, `rws`, `mgr`, `admin`) for various teams.
+
+3. **Validate CSV**
+   - Execute `perms validate perms.csv` to ensure the file structure is correct.
+   - Upload the CSV as an attachment and run `perms validate --vault-csv perms.csv` to validate it from the vault.
+
+4. **Dry‑Run Apply**
+   - Run `perms apply perms.csv --dry-run` to preview changes. Check the output log for expected folder paths and team names.
+
+5. **Apply Permissions**
+   - Execute `perms apply perms.csv` to apply permissions.
+   - After completion, verify:
+     - A root folder named `[Perms]` (or custom name) was created with team subfolders.
+     - Records are shared into the appropriate team folders.
+     - A log file attachment was uploaded to the "Perms Config" record.
+
+6. **Vault Verification**
+   - Browse the vault UI to confirm teams have the specified permissions on records.
+   - Remove the created folders and attachments after testing if desired.
+
+This sequence exercises the template, validation and apply workflows while confirming results directly in the vault.

--- a/keepercommander/api.py
+++ b/keepercommander/api.py
@@ -1538,6 +1538,7 @@ def load_records_in_shared_folder(params, shared_folder_uid, record_uids=None):
         record_set.difference_update(params.record_cache.keys())
 
 
+
 def get_pb2_records_request(params, request_type='add'):
     # type: (KeeperParams, str) -> Union[record_pb2.RecordsUpdateRequest, record_pb2.RecordsAddRequest]
     rq_by_type = dict(add=record_pb2.RecordsAddRequest, update=record_pb2.RecordsUpdateRequest)

--- a/keepercommander/commands/helpers/shared_folder.py
+++ b/keepercommander/commands/helpers/shared_folder.py
@@ -1,0 +1,56 @@
+from typing import Any
+
+from ... import api, crypto, utils
+from ...params import KeeperParams
+from ...error import KeeperApiError
+from ...proto import folder_pb2
+
+
+def add_team_to_shared_folder(params, folder_uid, team_uid, **permissions):
+    # type: (KeeperParams, str, str, ...) -> None
+    """Share a folder with a team using specified permission flags."""
+    api.load_team_keys(params, [team_uid])
+    team_keys = params.key_cache.get(team_uid)
+    if not team_keys:
+        raise KeeperApiError('team_key_not_found', f'Team key unavailable: {team_uid}')
+
+    sf = params.shared_folder_cache.get(folder_uid)
+    if not sf:
+        raise KeeperApiError('sf_not_found', f'Shared folder not found: {folder_uid}')
+
+    sf_key = sf.get('shared_folder_key_unencrypted')
+    if not sf_key:
+        raise KeeperApiError('sf_key_not_found', 'Shared folder key not found')
+
+    rq = folder_pb2.SharedFolderUpdateV3Request()
+    rq.sharedFolderUid = utils.base64_url_decode(folder_uid)
+    rq.forceUpdate = True
+
+    tq = folder_pb2.SharedFolderUpdateTeam()
+    tq.teamUid = utils.base64_url_decode(team_uid)
+    if 'manage_records' in permissions:
+        tq.manageRecords = folder_pb2.BOOLEAN_TRUE if permissions['manage_records'] else folder_pb2.BOOLEAN_FALSE
+    if 'manage_users' in permissions:
+        tq.manageUsers = folder_pb2.BOOLEAN_TRUE if permissions['manage_users'] else folder_pb2.BOOLEAN_FALSE
+    if 'can_edit' in permissions:
+        tq.canEdit = folder_pb2.BOOLEAN_TRUE if permissions['can_edit'] else folder_pb2.BOOLEAN_FALSE
+    if 'can_share' in permissions:
+        tq.canShare = folder_pb2.BOOLEAN_TRUE if permissions['can_share'] else folder_pb2.BOOLEAN_FALSE
+
+    if team_keys.aes:
+        tq.typedSharedFolderKey.encryptedKey = crypto.encrypt_aes_v2(sf_key, team_keys.aes)
+        tq.typedSharedFolderKey.encryptedKeyType = folder_pb2.encrypted_by_data_key_gcm
+    elif team_keys.ec:
+        ec_key = crypto.load_ec_public_key(team_keys.ec)
+        tq.typedSharedFolderKey.encryptedKey = crypto.encrypt_ec(sf_key, ec_key)
+        tq.typedSharedFolderKey.encryptedKeyType = folder_pb2.encrypted_by_public_key_ecc
+    elif team_keys.rsa and not params.forbid_rsa:
+        rsa_key = crypto.load_rsa_public_key(team_keys.rsa)
+        tq.typedSharedFolderKey.encryptedKey = crypto.encrypt_rsa(sf_key, rsa_key)
+        tq.typedSharedFolderKey.encryptedKeyType = folder_pb2.encrypted_by_public_key
+    else:
+        raise KeeperApiError('team_public_key_missing', f'Team public key missing: {team_uid}')
+
+    rq.sharedFolderAddTeam.append(tq)
+    api.communicate_rest(params, rq, 'vault/shared_folder_update_v3',
+                         rs_type=folder_pb2.SharedFolderUpdateV3Response)

--- a/keepercommander/commands/perms_command.py
+++ b/keepercommander/commands/perms_command.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import List, Dict, Any, Optional, Union
 
 from keepercommander import api
+from .helpers.shared_folder import add_team_to_shared_folder
 from keepercommander.commands.base import GroupCommand, Command
 from keepercommander.params import KeeperParams
 from keepercommander.commands.folder import FolderMakeCommand
@@ -286,7 +287,7 @@ class KeeperPerms:
         api.move_record(self.params, record_uid, folder_uid, shared=True)
 
     def add_team_to_shared_folder(self, team_uid: str, folder_uid: str, permissions: Dict[str, bool]):
-        api.add_team_to_shared_folder(self.params, folder_uid, team_uid, **permissions)
+        add_team_to_shared_folder(self.params, folder_uid, team_uid, **permissions)
 
     def permission_level_to_flags(self, level: str) -> Dict[str, bool]:
         levels = {


### PR DESCRIPTION
## Summary
- move new team sharing helper from `api` to `commands/helpers/shared_folder`
- update `perms` command to use the helper

## Testing
- `pytest -q` *(fails: FileNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_b_687d7aa819588322ad61d3c19a417cfb