### PR TITLE
Add live perms tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,10 @@ installing dependencies, run them with:
 pytest -q -m integration
 ```
 
+Live tests for the `perms` command use the same `tests/vault.json` file. The
+sandbox environment keeps a persistent login so no additional configuration is
+needed.
+
 After the live tests complete, confirm that no unexpected data remains in the
 Vault. You can use standard `keeper` commands to inspect and clean up records.
 Document any vault changes or cleanup steps in the `codex` directory.

--- a/tests/test_perms_live.py
+++ b/tests/test_perms_live.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+from unittest import TestCase
+
+import pytest
+
+from data_config import read_config_file
+from keepercommander.params import KeeperParams
+from keepercommander import api
+from keepercommander.commands.perms_command import KeeperPerms
+
+
+@pytest.mark.integration
+class TestPermsLive(TestCase):
+    params = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.params = KeeperParams()
+        read_config_file(cls.params, 'vault.json')
+        api.login(cls.params)
+
+    @classmethod
+    def tearDownClass(cls):
+        api.logout(cls.params)
+
+    def test_generate_and_validate_template(self):
+        params = TestPermsLive.params
+        keeper = KeeperPerms(params)
+        with tempfile.NamedTemporaryFile('w+', delete=False) as tmp:
+            path = tmp.name
+        try:
+            keeper.generate_template(path)
+            self.assertTrue(os.path.isfile(path))
+            valid = keeper.validate_csv(path)
+            self.assertTrue(valid)
+        finally:
+            os.unlink(path)
+
+    def test_permission_flags(self):
+        keeper = KeeperPerms(TestPermsLive.params)
+        flags = keeper.permission_level_to_flags('rw')
+        expected = {'manage_records': False, 'manage_users': False, 'can_edit': True, 'can_share': False}
+        self.assertEqual(flags, expected)


### PR DESCRIPTION
## Summary
- add integration tests for perms command with persistent login
- document persistent login config in AGENTS guidelines

## Testing
- `pytest -q` *(fails: FileNotFoundError for `tests/vault.json`)*

------
https://chatgpt.com/codex/tasks/task_b_687e745f1bb48322ae37026ffabb285d