### PR TITLE
Clarify perms test config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,12 @@ installing dependencies, run them with:
 pytest -q -m integration
 ```
 
+Live tests for the `perms` command rely on the environment's persistent
+`config.json` (for example `~/.keeper/config.json`). No separate
+`tests/vault.json` file is required. The sandbox will reuse any stored
+credentials, but tests may fail if the config does not include them. Do not
+modify the configuration file.
+
 After the live tests complete, confirm that no unexpected data remains in the
 Vault. You can use standard `keeper` commands to inspect and clean up records.
 Document any vault changes or cleanup steps in the `codex` directory.

--- a/codex/perms_live_test_log.md
+++ b/codex/perms_live_test_log.md
@@ -1,0 +1,13 @@
+# `perms` Live Test Attempt
+
+Attempted to run `keeper whoami` and the `perms` integration tests using the
+default configuration at `~/.keeper/config.json`. Commander prompted for an SSO
+login URL, indicating that automatic login details were not present. As a
+result, the tests could not proceed and no changes were made to the Keeper
+Vault.
+
+## July 21, 2025
+
+Tried running `pytest -q tests/test_perms_live.py -m integration` with the
+updated credentials. Commander still prompted for an SSO login URL and the tests
+were unable to proceed automatically.

--- a/tests/test_perms_live.py
+++ b/tests/test_perms_live.py
@@ -1,0 +1,51 @@
+import os
+import tempfile
+from unittest import TestCase
+
+import pytest
+
+from data_config import read_config_file
+from keepercommander.params import KeeperParams
+from keepercommander import api, cli
+from keepercommander.commands.perms_command import KeeperPerms
+
+
+@pytest.mark.integration
+class TestPermsLive(TestCase):
+    params = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.params = KeeperParams()
+        # use the sandbox's persistent config; no vault.json required
+        keeper_config = os.path.join(os.path.expanduser('~'), '.keeper', 'config.json')
+        read_config_file(cls.params, keeper_config)
+        api.login(cls.params)
+
+    @classmethod
+    def tearDownClass(cls):
+        cli.do_command(cls.params, 'logout')
+
+    def test_generate_and_validate_template(self):
+        params = TestPermsLive.params
+        keeper = KeeperPerms(params)
+        with tempfile.NamedTemporaryFile('w+', delete=False) as tmp:
+            path = tmp.name
+        try:
+            keeper.generate_template(path)
+            self.assertTrue(os.path.isfile(path))
+            valid = keeper.validate_csv(path)
+            self.assertTrue(valid)
+        finally:
+            os.unlink(path)
+
+    def test_permission_flags(self):
+        keeper = KeeperPerms(TestPermsLive.params)
+        flags = keeper.permission_level_to_flags('rw')
+        expected = {
+            'manage_records': False,
+            'manage_users': False,
+            'can_edit': True,
+            'can_share': False,
+        }
+        self.assertEqual(flags, expected)


### PR DESCRIPTION
## Summary
- use default config in perms live test
- clarify persistent config in contributor guidelines
- note missing automatic login in perms live test log

## Testing
- `pytest -q` *(fails: FileNotFoundError for config.json, vault.json, enterprise.json)*
- `pytest -q tests/test_perms_live.py -m integration` *(fails: prompts for SSO login)*

------
https://chatgpt.com/codex/tasks/task_b_687e745f1bb48322ae37026ffabb285d