### PR TITLE
Document rotation edit command

### DIFF
--- a/DISCOVERY_ROTATION.md
+++ b/DISCOVERY_ROTATION.md
@@ -1,0 +1,86 @@
+# Discovery Rotation Module Overview
+
+`keepercommander.commands.discoveryrotation` defines the majority of Keeper's
+PAM related CLI commands.  The module registers the top level `pam` group and
+implements subcommands for gateway management, configuration management and
+password rotation.  This document focuses on the `pam rotation edit` command and
+provides an overview of how the module orchestrates PAM rotation updates.
+
+## Purpose
+
+The command configures password rotation settings for PAM records. It can target a single record via `--record` or all records in a folder via `--folder`. The settings include enabling or disabling rotation, selecting a PAM Configuration, defining password complexity, linking the record to a resource, and setting rotation schedules.
+
+The command is mapped to the `pam rotation edit` CLI verb in `PAMRotationCommand` within `discoveryrotation.py`.
+
+## Key Steps
+
+1. **Resolve record or folder** – The command resolves record UIDs or folder UIDs from CLI arguments. When a folder is specified, it traverses the folder tree and gathers records matching the provided title pattern.
+2. **Validate record types** – Only PAM record types (`pamDatabase`, `pamDirectory`, `pamMachine`, `pamUser`, `pamRemoteBrowser`) are processed. Other records are skipped with an error message.
+3. **Load PAM Configuration** – If `--config` points to a PAM Configuration record, it is loaded and used as the source of default schedule and resource information.
+4. **Parse schedule** – The command accepts schedule definitions either as JSON (`--schedulejson`) or cron strings (`--schedulecron`). Cron values must contain exactly five components: minute, hour, day of month, month, and day of week. Invalid cron strings raise `CommandError`.
+5. **Determine password complexity** – Complexity rules are parsed from the `--complexity` flag. They are validated and then encrypted before being sent to the router service.
+6. **Build router requests** – For each target record, a `RouterRecordRotationRequest` protobuf is created containing schedule, complexity and resource linkage information. These requests are submitted to the PAM Router service via `router_set_record_rotation_information`.
+7. **Confirmation prompts** – When multiple records will be modified, the command prints a summary table and prompts the user before performing the operation unless `--force` is used.
+
+## Module Structure
+
+`discoveryrotation.py` groups related PAM commands under several classes:
+
+- **`PAMControllerCommand`** – registers the `pam` top level command and
+  subcommands for gateways, configurations, rotation and other helper actions.
+- **`PAMCreateRecordRotationCommand`** – implements `pam rotation edit`.  This is
+  the most complex command and performs schedule parsing, validation and request
+  submission described above.
+- **`PAMListRecordRotationCommand`** – displays existing rotation settings for
+  PAM user records.
+- **`PAMGatewayListCommand`** – lists available PAM gateways.  Other helper
+  classes handle discovery jobs, debugging and service configuration.
+
+Rotation editing uses helper functions such as `TunnelDAG` to ensure records are
+linked to the correct configuration and resource, and `router_set_record_rotation_information`
+to persist the changes via Keeper's router service.
+
+## Schedule Only Mode
+
+The `--schedule-only` flag updates the rotation schedule without modifying the
+resource link, password complexity, or enable/disable status. When used with
+`--folder`, records that do not currently have rotation enabled are skipped to
+avoid accidental configuration changes.
+
+Example:
+
+```bash
+keeper pam rotation edit --folder Finance --schedulecron "0 1 * * *" --schedule-only -f
+```
+
+This updates the cron schedule on all PAM records in the *Finance* folder that
+already have rotation enabled.
+
+## Additional Edge Cases
+
+- Records representing user credentials may be stored in folders separate from
+  their associated resources. When scheduling rotations for a folder, ensure
+  that each record is still linked to the correct resource. The command now
+  skips records that have rotation disabled when `--schedule-only` is used on a
+  folder.
+
+## Edge Cases
+
+- Supplying both `--record` and `--folder` results in a `CommandError`.
+- Specifying a cron expression with fewer or more than five fields triggers a `CommandError` (see unit test `TestCronScheduleParsing`).
+- If a target record has no associated resource and none is provided via `--resource`, the command aborts with a message instructing how to associate a resource.
+- Attempting to enable rotation when the resource lacks admin credentials also results in an error.
+- Using `--schedule-only` on a folder skips records that either have rotation
+  disabled or have never been configured for rotation.  Re-enable or configure
+  the record first if schedule-only is desired.
+
+## Live Testing
+
+The command requires an authenticated session with a Keeper vault and appropriate PAM records. Attempting to run the command without valid credentials will fail during login. In this environment no Keeper vault configuration is available, so a live test cannot be performed. Running:
+
+```bash
+keeper pam rotation edit --record RECORD_UID --enable
+```
+
+results in an authentication error because no config or login is present.
+

--- a/PAM_ROTATION_TEST_PLAN.md
+++ b/PAM_ROTATION_TEST_PLAN.md
@@ -1,0 +1,42 @@
+# PAM Rotation Manual Test Plan
+
+This plan verifies schedule-only updates and skipping of disabled records.
+
+## Prerequisites
+- Authenticated Keeper Commander session.
+- A folder with several PAM records:
+  - Some records already have rotation enabled.
+  - Some records are not configured for rotation or are disabled.
+
+## Steps
+1. **Update schedule only**
+   ```bash
+   keeper pam rotation edit --folder "Finance" --schedulecron "0 1 * * *" --schedule-only -f
+   ```
+   - Expect: Only records with rotation enabled have their schedule changed. Other records are reported as skipped.
+
+2. **Verify unchanged settings**
+   For one of the updated records, run:
+   ```bash
+   keeper pam rotation info --record RECORD_UID
+   ```
+   - Confirm that the configuration UID, resource UID and password complexity are unchanged, but the schedule shows the new cron string.
+
+3. **Attempt on disabled record**
+   ```bash
+   keeper pam rotation edit --record DISABLED_UID --schedulecron "0 2 * * *" --schedule-only
+   ```
+   - Expect: Command fails with a message that the record has no rotation information.
+
+4. **Enable rotation then update**
+   ```bash
+   keeper pam rotation edit --record DISABLED_UID --enable --config CONFIG_UID --resource RESOURCE_UID -f
+   keeper pam rotation edit --record DISABLED_UID --schedulecron "0 3 * * *" --schedule-only -f
+   ```
+  - Expect: After enabling, schedule-only modifies just the schedule.
+
+## Notes
+
+The above steps require access to a Keeper vault.  They cannot be executed in
+this automated test environment because no Keeper credentials are available.
+

--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -291,6 +291,8 @@ class PAMCreateRecordRotationCommand(Command):
                                 action='store_true', help='Schedule On Demand')
     schedule_group.add_argument('--schedule-config', '-sf', required=False, dest='schedule_config',
                                 action='store_true', help='Schedule from Configuration')
+    parser.add_argument('--schedule-only', '-so', dest='schedule_only', action='store_true',
+                        help='Only update the rotation schedule without changing other settings')
     parser.add_argument('--complexity',   '-x',  required=False, dest='pwd_complexity', action='store',
                         help='Password complexity: length, upper, lower, digits, symbols. Ex. 32,5,5,5,5[,SPECIAL CHARS]')
     parser.add_argument('--admin-user', '-a', required=False, dest='admin', action='store',
@@ -303,6 +305,14 @@ class PAMCreateRecordRotationCommand(Command):
         return PAMCreateRecordRotationCommand.parser
 
     def execute(self, params, **kwargs):
+        """Configure rotation settings for one or multiple PAM records.
+
+        The command accepts either ``--record`` or ``--folder`` to target
+        records. It validates schedule options, password complexity and
+        resource linkage and then submits rotation requests to the Keeper
+        PAM router service.
+        """
+
         record_uids = set()   # type: Set[str]
 
         folder_uids = set()
@@ -520,6 +530,111 @@ class PAMCreateRecordRotationCommand(Command):
 
 
             current_record_rotation = params.record_rotation_cache.get(target_record.record_uid)
+            schedule_only = kwargs.get('schedule_only')
+            if schedule_only:
+                if kwargs.get('folder_name') and (not current_record_rotation or current_record_rotation.get('disabled')):
+                    skipped_records.append([target_record.record_uid, target_record.title,
+                                            'Rotation not enabled', 'Skipped'])
+                    return
+                if not current_record_rotation:
+                    skipped_records.append([target_record.record_uid, target_record.title,
+                                            'No rotation info', 'Skipped'])
+                    return
+
+                record_config_uid = current_record_rotation.get('configuration_uid')
+                record_pam_config = pam_configurations.get(record_config_uid, pam_config)
+                record_schedule_data = schedule_data
+                if record_schedule_data is None:
+                    try:
+                        cs = current_record_rotation.get('schedule')
+                        record_schedule_data = json.loads(cs) if cs else []
+                    except:
+                        record_schedule_data = []
+                pwd_complexity_rule_list_encrypted = utils.base64_url_decode(current_record_rotation.get('pwd_complexity', ''))
+                record_resource_uid = current_record_rotation.get('resourceUid')
+                disabled = current_record_rotation.get('disabled', False)
+
+                schedule = 'On-Demand'
+                if isinstance(record_schedule_data, list) and len(record_schedule_data) > 0:
+                    if isinstance(record_schedule_data[0], dict):
+                        schedule = record_schedule_data[0].get('type')
+                complexity = ''
+                if pwd_complexity_rule_list_encrypted:
+                    try:
+                        decrypted_complexity = crypto.decrypt_aes_v2(pwd_complexity_rule_list_encrypted, target_record.record_key)
+                        c = json.loads(decrypted_complexity.decode())
+                        complexity = f"{c.get('length', 0)},{c.get('caps', 0)},{c.get('lowercase', 0)},{c.get('digits', 0)},{c.get('special', 0)},{c.get('specialChars', PAM_DEFAULT_SPECIAL_CHAR)}"
+                    except Exception:
+                        pass
+
+                valid_records.append([
+                    target_record.record_uid, target_record.title, not disabled, record_config_uid,
+                    record_resource_uid, schedule, complexity])
+
+                rq = router_pb2.RouterRecordRotationRequest()
+                rq.revision = current_record_rotation.get('revision', 0)
+                rq.recordUid = utils.base64_url_decode(target_record.record_uid)
+                rq.configurationUid = utils.base64_url_decode(record_config_uid)
+                rq.resourceUid = utils.base64_url_decode(record_resource_uid) if record_resource_uid else b''
+                rq.schedule = json.dumps(record_schedule_data) if record_schedule_data else ''
+                rq.pwdComplexity = pwd_complexity_rule_list_encrypted
+                rq.disabled = disabled
+                if noop_rotation:
+                    rq.noop = True
+                    rq.resourceUid = b''
+                r_requests.append(rq)
+                return
+            schedule_only = kwargs.get('schedule_only')
+            if schedule_only:
+                if kwargs.get('folder_name') and (not current_record_rotation or current_record_rotation.get('disabled')):
+                    skipped_records.append([target_record.record_uid, target_record.title,
+                                            'Rotation not enabled', 'Skipped'])
+                    return
+                if not current_record_rotation:
+                    skipped_records.append([target_record.record_uid, target_record.title,
+                                            'No rotation info', 'Skipped'])
+                    return
+
+                record_config_uid = current_record_rotation.get('configuration_uid')
+                record_resource_uid = current_record_rotation.get('resourceUid')
+                record_pam_config = pam_configurations.get(record_config_uid, pam_config)
+                record_schedule_data = schedule_data
+                if record_schedule_data is None:
+                    try:
+                        cs = current_record_rotation.get('schedule')
+                        record_schedule_data = json.loads(cs) if cs else []
+                    except:
+                        record_schedule_data = []
+                pwd_complexity_rule_list_encrypted = utils.base64_url_decode(current_record_rotation.get('pwd_complexity', ''))
+                disabled = current_record_rotation.get('disabled', False)
+
+                schedule = 'On-Demand'
+                if isinstance(record_schedule_data, list) and len(record_schedule_data) > 0:
+                    if isinstance(record_schedule_data[0], dict):
+                        schedule = record_schedule_data[0].get('type')
+                complexity = ''
+                if pwd_complexity_rule_list_encrypted:
+                    try:
+                        decrypted_complexity = crypto.decrypt_aes_v2(pwd_complexity_rule_list_encrypted, target_record.record_key)
+                        c = json.loads(decrypted_complexity.decode())
+                        complexity = f"{c.get('length', 0)},{c.get('caps', 0)},{c.get('lowercase', 0)},{c.get('digits', 0)},{c.get('special', 0)},{c.get('specialChars', PAM_DEFAULT_SPECIAL_CHAR)}"
+                    except Exception:
+                        pass
+
+                valid_records.append([
+                    target_record.record_uid, target_record.title, not disabled, record_config_uid,
+                    record_resource_uid, schedule, complexity])
+
+                rq = router_pb2.RouterRecordRotationRequest()
+                rq.revision = current_record_rotation.get('revision', 0)
+                rq.recordUid = utils.base64_url_decode(target_record.record_uid)
+                rq.configurationUid = utils.base64_url_decode(record_config_uid)
+                rq.resourceUid = utils.base64_url_decode(record_resource_uid) if record_resource_uid else b''
+                rq.schedule = json.dumps(record_schedule_data) if record_schedule_data else ''
+                rq.pwdComplexity = pwd_complexity_rule_list_encrypted
+                rq.disabled = disabled
+                r_requests.append(rq)
+                return
 
             # 1. PAM Configuration UID
             record_config_uid = _dag.record.record_uid

--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -584,57 +584,6 @@ class PAMCreateRecordRotationCommand(Command):
                     rq.resourceUid = b''
                 r_requests.append(rq)
                 return
-            schedule_only = kwargs.get('schedule_only')
-            if schedule_only:
-                if kwargs.get('folder_name') and (not current_record_rotation or current_record_rotation.get('disabled')):
-                    skipped_records.append([target_record.record_uid, target_record.title,
-                                            'Rotation not enabled', 'Skipped'])
-                    return
-                if not current_record_rotation:
-                    skipped_records.append([target_record.record_uid, target_record.title,
-                                            'No rotation info', 'Skipped'])
-                    return
-
-                record_config_uid = current_record_rotation.get('configuration_uid')
-                record_resource_uid = current_record_rotation.get('resourceUid')
-                record_pam_config = pam_configurations.get(record_config_uid, pam_config)
-                record_schedule_data = schedule_data
-                if record_schedule_data is None:
-                    try:
-                        cs = current_record_rotation.get('schedule')
-                        record_schedule_data = json.loads(cs) if cs else []
-                    except:
-                        record_schedule_data = []
-                pwd_complexity_rule_list_encrypted = utils.base64_url_decode(current_record_rotation.get('pwd_complexity', ''))
-                disabled = current_record_rotation.get('disabled', False)
-
-                schedule = 'On-Demand'
-                if isinstance(record_schedule_data, list) and len(record_schedule_data) > 0:
-                    if isinstance(record_schedule_data[0], dict):
-                        schedule = record_schedule_data[0].get('type')
-                complexity = ''
-                if pwd_complexity_rule_list_encrypted:
-                    try:
-                        decrypted_complexity = crypto.decrypt_aes_v2(pwd_complexity_rule_list_encrypted, target_record.record_key)
-                        c = json.loads(decrypted_complexity.decode())
-                        complexity = f"{c.get('length', 0)},{c.get('caps', 0)},{c.get('lowercase', 0)},{c.get('digits', 0)},{c.get('special', 0)},{c.get('specialChars', PAM_DEFAULT_SPECIAL_CHAR)}"
-                    except Exception:
-                        pass
-
-                valid_records.append([
-                    target_record.record_uid, target_record.title, not disabled, record_config_uid,
-                    record_resource_uid, schedule, complexity])
-
-                rq = router_pb2.RouterRecordRotationRequest()
-                rq.revision = current_record_rotation.get('revision', 0)
-                rq.recordUid = utils.base64_url_decode(target_record.record_uid)
-                rq.configurationUid = utils.base64_url_decode(record_config_uid)
-                rq.resourceUid = utils.base64_url_decode(record_resource_uid) if record_resource_uid else b''
-                rq.schedule = json.dumps(record_schedule_data) if record_schedule_data else ''
-                rq.pwdComplexity = pwd_complexity_rule_list_encrypted
-                rq.disabled = disabled
-                r_requests.append(rq)
-                return
 
             # 1. PAM Configuration UID
             record_config_uid = _dag.record.record_uid

--- a/unit-tests/pam/test_pam_rotation.py
+++ b/unit-tests/pam/test_pam_rotation.py
@@ -82,6 +82,10 @@ if sys.version_info >= (3, 8):
             self.assertEqual(args.record_name, 'record_uid')
             self.assertTrue(args.force)
 
+        def test_parser_schedule_only(self):
+            args = self.parser.parse_args(['--record', 'record_uid', '--schedule-only'])
+            self.assertTrue(args.schedule_only)
+
         @patch('keepercommander.vault.KeeperRecord.load')
         @patch('keepercommander.commands.discoveryrotation.TunnelDAG')
         @patch('keepercommander.rest_api.SERVER_PUBLIC_KEYS', {8: ec.generate_private_key(ec.SECP256R1()).public_key()})
@@ -407,7 +411,7 @@ if sys.version_info >= (3, 8):
             self.assertTrue(mock_pam_configurations_get_all.called)
 
 
-    class TestPAMGatewayListCommand(unittest.TestCase):
+class TestPAMGatewayListCommand(unittest.TestCase):
 
         def setUp(self):
             self.command = PAMGatewayListCommand()
@@ -507,3 +511,14 @@ if sys.version_info >= (3, 8):
             self.assertTrue(mock_router_get_connected_gateways.called)
             self.assertTrue(mock_get_all_gateways.called)
             self.assertTrue(mock_get_router_url.called)
+
+
+class TestCronScheduleParsing(unittest.TestCase):
+
+    def setUp(self):
+        self.command = PAMCreateRecordRotationCommand()
+
+    def test_invalid_cron_components(self):
+        params, _ = create_mock_params_and_record()
+        with self.assertRaises(CommandError):
+            self.command.execute(params, record_name='uid', schedule_cron_data=['0 12 * *'])

--- a/unit-tests/pam/test_pam_rotation.py
+++ b/unit-tests/pam/test_pam_rotation.py
@@ -522,3 +522,4 @@ class TestCronScheduleParsing(unittest.TestCase):
         params, _ = create_mock_params_and_record()
         with self.assertRaises(CommandError):
             self.command.execute(params, record_name='uid', schedule_cron_data=['0 12 * *'])
+


### PR DESCRIPTION
## Summary
- explain schedule-only mode in `DISCOVERY_ROTATION.md`
- add manual test plan for rotation scheduling
- support `--schedule-only` option in `pam rotation edit`
- skip disabled records when scheduling via folder
- expand docs explaining discoveryrotation module
- add parser test for schedule-only flag

## Testing
- `pytest -q unit-tests/pam/test_pam_rotation.py::TestCronScheduleParsing::test_invalid_cron_components -q`
- `pytest -q unit-tests/pam/test_pam_rotation.py::TestPAMCreateRecordRotationCommand::test_parser_schedule_only -q`
- `pytest -q unit-tests/pam/test_pam_rotation.py -q`


------
https://chatgpt.com/codex/tasks/task_b_6884ef15fb8c832282f0aba617493f07